### PR TITLE
Add getDBAsyncSlaves, getDBSyncSlaves

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,6 +1,6 @@
 0.4.0 -- 2014-MM-DD
 -------------------
-
+ - New methods: getDBSyncSlaves, getDBAsyncSlaves
  - Switch to 3-clause BSD license (#8)
 
 0.3.0 -- 2013-12-16

--- a/lib/carto_metadata.js
+++ b/lib/carto_metadata.js
@@ -29,9 +29,12 @@ module.exports = function(redis_opts) {
 
     var me = {
         user_metadata_db: 5,
+        db_metadata_db: 5,
         table_metadata_db: 0,
         user_key:  "rails:users:<%= username %>",
         table_key: "rails:<%= database_name %>:<%= table_name %>",
+        sync_slaves_key: "db:<%= dbhost %>:sync_slaves",
+        async_slaves_key: "db:<%= dbhost %>:async_slaves",
         global_mapview_key: "user:<%= username %>:mapviews:global",
         tagged_mapview_key: "user:<%= username %>:mapviews:stat_tag:<%= stat_tag %>"
     };
@@ -349,6 +352,33 @@ module.exports = function(redis_opts) {
             }
         );
     };
+
+    /**
+     * Get the synchronous slaves for a database host.
+     * Those slaves are assumed to be synchronized with the master.
+     * If they exist, they are only to be used for read queries.
+     *
+     * @param dbhost - database host of the master database to lookup
+     * @param callback - gets called with args(err, slaves) 
+     */
+    me.getDBSyncSlaves = function(dbhost, callback){
+        var redisKey = _.template(this.sync_slaves_key, {dbhost:dbhost});
+        this.redisCmd(this.db_metadata_db,'SMEMBERS',[redisKey],callback);
+    }
+
+    /**
+     * Get the asynchronous slaves for a database host.
+     * Those slaves aren't guaranteed to be synchronized with the master
+     * due to replication lag, which should be taken into account.
+     * If they exists, they are only be used for read queries.
+     *
+     * @param dbhost - database host of the master database to lookup
+     * @param callback - gets called with args(err, slaves) 
+     */
+    me.getDBAsyncSlaves = function(dbhost, callback){
+        var redisKey = _.template(this.async_slaves_key, {dbhost:dbhost});
+        this.redisCmd(this.db_metadata_db,'SMEMBERS',[redisKey],callback);
+    }
 
     /**
      * Get the map_metadata for a table;

--- a/test/carto_metadata.test.js
+++ b/test/carto_metadata.test.js
@@ -143,4 +143,31 @@ test('can retrieve map key', function(done){
     });
 });
 
+test('retrieves sync slaves if they exist', function(done){
+    MetaData.getDBSyncSlaves('1.2.3.4', function(err, data){
+        assert.deepEqual(data, ['1.2.3.5','1.2.3.6']);
+        done();
+    });
+});
+
+test('retrieves empty if there are no sync slaves', function(done){
+    MetaData.getDBSyncSlaves('2.3.4.5', function(err, data){
+        assert.deepEqual(data, []);
+        done();
+    });
+});
+
+test('retrieves async slaves if they exist', function(done){
+    MetaData.getDBAsyncSlaves('1.2.3.4', function(err, data){
+        assert.deepEqual(data, ['1.2.3.7','1.2.3.8']);
+        done();
+    });
+});
+
+test('retrieves empty if there are no async slaves', function(done){
+    MetaData.getDBAsyncSlaves('2.3.4.5', function(err, data){
+        assert.deepEqual(data, []);
+        done();
+    });
+});
 });

--- a/test/support/prepare_db.sh
+++ b/test/support/prepare_db.sh
@@ -44,6 +44,11 @@ HMSET rails:oauth_access_tokens:l0lPbtP68ao8NfStCiA3V3neqfM03JKhToxhUQTR \
   time sometime 
 EOF
 
+cat <<EOF | redis-cli -p ${REDIS_PORT} -n 5
+SADD db:1.2.3.4:sync_slaves 1.2.3.5 1.2.3.6
+SADD db:1.2.3.4:async_slaves 1.2.3.7 1.2.3.8
+EOF
+
 echo "ok, you can run test now"
 
 


### PR DESCRIPTION
We're going to introduce support for database slaves on our infrastructure.
They are identified by the IP of their master cluster. They're also to be read from the same Redis database as the user_metadata, with keys:
`db:[database_ip]:sync_slaves`
`db:[database_ip]:async_slaves`
This introduces support for reading them.

Use of these slaves is optional and only used for performance matters: the "original" database_ip is assumed to be always available, and the keys may return empty (due to not being set).
- If we're using _only_ read queries and require consistency, it is permissible to balance between the master DB and their synchronous slaves.
- If we're using _only_ read queries and can manage (or don't care about) replication lag, it is permissible to balance between sync_slaves, async_slaves and the master<.
