### PR TITLE
Increment stat_tag total counter besides date ones

### DIFF
--- a/lib/carto_metadata.js
+++ b/lib/carto_metadata.js
@@ -53,6 +53,7 @@ module.exports = function(redis_opts) {
         async_slaves_key: dot.template("db:{{=it.dbhost}}:async_slaves"),
         global_mapview_key: dot.template("user:{{=it.username}}:mapviews:global"),
         tagged_mapview_key: dot.template("user:{{=it.username}}:mapviews:stat_tag:{{=it.stat_tag}}"),
+        tagged_total_mapview_key: dot.template("user:{{=it.username}}:mapviews:stat_tag:{{=it.stat_tag}}"),
         // limits
         user_tiler_limits: dot.template("limits:tiler:{{=it.username}}")
     };
@@ -139,10 +140,12 @@ module.exports = function(redis_opts) {
             that.redisCmd(me.user_metadata_db, 'ZINCRBY', [redisKey, 1, mapViewKey], callback);
         } else {
             var tagKey = that.tagged_mapview_key({username: username, stat_tag: stat_tag});
+            var tagTotalKey = that.tagged_total_mapview_key({username: username, stat_tag: stat_tag});
 
             that.redisMultiCmd(me.user_metadata_db, [
                 ['ZINCRBY', globalKey, 1, mapViewKey],
-                ['ZINCRBY', tagKey, 1, mapViewKey]
+                ['ZINCRBY', tagKey, 1, mapViewKey],
+                ['ZINCRBY', tagTotalKey, 1, 'total']
             ], callback);
         }
     };

--- a/lib/carto_metadata.js
+++ b/lib/carto_metadata.js
@@ -53,7 +53,6 @@ module.exports = function(redis_opts) {
         async_slaves_key: dot.template("db:{{=it.dbhost}}:async_slaves"),
         global_mapview_key: dot.template("user:{{=it.username}}:mapviews:global"),
         tagged_mapview_key: dot.template("user:{{=it.username}}:mapviews:stat_tag:{{=it.stat_tag}}"),
-        tagged_total_mapview_key: dot.template("user:{{=it.username}}:mapviews:stat_tag:{{=it.stat_tag}}"),
         // limits
         user_tiler_limits: dot.template("limits:tiler:{{=it.username}}")
     };
@@ -140,12 +139,11 @@ module.exports = function(redis_opts) {
             that.redisCmd(me.user_metadata_db, 'ZINCRBY', [redisKey, 1, mapViewKey], callback);
         } else {
             var tagKey = that.tagged_mapview_key({username: username, stat_tag: stat_tag});
-            var tagTotalKey = that.tagged_total_mapview_key({username: username, stat_tag: stat_tag});
 
             that.redisMultiCmd(me.user_metadata_db, [
                 ['ZINCRBY', globalKey, 1, mapViewKey],
                 ['ZINCRBY', tagKey, 1, mapViewKey],
-                ['ZINCRBY', tagTotalKey, 1, 'total']
+                ['ZINCRBY', tagKey, 1, 'total']
             ], callback);
         }
     };

--- a/test/carto_metadata.test.js
+++ b/test/carto_metadata.test.js
@@ -250,7 +250,7 @@ test('retrieves empty if there are no async slaves', function(done){
         });
     });
 
-    test('incMapviewCount increments both counters', function(done) {
+    test('incMapviewCount increments tree counters', function(done) {
         var getMapViewKeyFunc = MetaData.getMapViewKey;
         MetaData.getMapViewKey = function() {
             return '20140101';
@@ -258,11 +258,13 @@ test('retrieves empty if there are no async slaves', function(done){
         MetaData.incMapviewCount('vizzuality', 'foo', function(err, values) {
             MetaData.getMapViewKey = getMapViewKeyFunc;
 
-            assert.equal(values.length, 2, 'expected two values, got ' + values.length);
+            assert.equal(values.length, 3, 'expected three values, got ' + values.length);
             var global = values[0];
             var tag = values[1];
+            var tagTotal = values[2];
             assert.equal(global, 2);
             assert.equal(tag, 1);
+            assert.equal(tagTotal, 1);
 
             done();
         })


### PR DESCRIPTION
Now for every map view we increment a global counter per user and a counter per day per stat_tag.
This will increment too a total counter for every stat_tag

Although tagged_mapview_key and tagged_total_mapview_key are actually the same, I duplicate them so it's cleaner. Feel free to remove that duplication.

Please @rochoa @javisantana CR