### PR TITLE
Keep module's public surface

### DIFF
--- a/lib/carto_metadata.js
+++ b/lib/carto_metadata.js
@@ -628,7 +628,7 @@ module.exports = function(redis_opts) {
      ******************************************************************************************************************/
 
     me.getUserBasicInfo = function (username, callback) {
-        const fields = ['id', 'database_host', 'database_name', 'database_master_role', 'database_master_password'];
+        const fields = ['id', 'database_host', 'database_name', 'database_password', 'database_publicuser'];
         this.getMultipleUserParams(username, fields, callback);
     };
 

--- a/lib/carto_metadata.js
+++ b/lib/carto_metadata.js
@@ -677,6 +677,10 @@ module.exports = function(redis_opts) {
                 }
             })
 
+            if (!Object.keys(paramsMap).length) {
+                return callback();
+            }
+
             callback(null, paramsMap);
         });
     };

--- a/lib/carto_metadata.js
+++ b/lib/carto_metadata.js
@@ -628,7 +628,7 @@ module.exports = function(redis_opts) {
      ******************************************************************************************************************/
 
     me.getUserBasicInfo = function (username, callback) {
-        const fields = ['id', 'database_host', 'database_name'];
+        const fields = ['id', 'database_host', 'database_name', 'database_master_role', 'database_master_password'];
         this.getMultipleUserParams(username, fields, callback);
     };
 

--- a/lib/carto_metadata.js
+++ b/lib/carto_metadata.js
@@ -623,39 +623,67 @@ module.exports = function(redis_opts) {
         });
     };
 
+    /*******************************************************************************************************************
+     * AUTH
+     ******************************************************************************************************************/
+
     me.getUserBasicInfo = function (username, callback) {
         const fields = ['id', 'database_host', 'database_name'];
         this.getMultipleUserParams(username, fields, callback);
     };
 
-    const apiKeyFields = [
-        'user',
-        'type',
-        'dbRole',
-        'dbPassword',
-        `grants_${options.apiName}`
-    ];
+    me.getApiKey = function (username, apiKeyToken, apiName, callback) {
+        const defaultParser = value => value;
+        const authParams = {
+            user: {
+                name: 'user',
+                parser: defaultParser
+            },
+            type: {
+                name: 'type',
+                parser: defaultParser
+            },
+            db_role: {
+                name: 'dbRole',
+                parser: defaultParser
+            },
+            db_password: {
+                name: 'dbPassword',
+                parser: defaultParser
+            },
+            [`grants_${apiName}`]: {
+                name: `grants${apiName.charAt(0).toUpperCase() + apiName.slice(1)}`,
+                parser: value => Boolean(value).valueOf()
+            }
+        };
 
-    me.getApiKey = function ({ username, apiKeyToken }, callback) {
+        this.getMultipleAuthParams(username, apiKeyToken, authParams, callback)
+    };
 
+    me.getMultipleAuthParams = function (username, apiKeyToken, authParams, callback) {
         const redisKey = `api_keys:${username}:${apiKeyToken}`;
+        const authParamsKeys = Object.keys(authParams);
 
-        this.mRetrieve(this.user_metadata_db, redisKey, apiKeyFields, function (err, dbValues) {
+        this.mRetrieve(this.user_metadata_db, redisKey, authParamsKeys, (err, authValues) => {
             if (err) {
                 return callback(err, null);
-            } else {
-                const element = {};
-                apiKeyFields.forEach((field, pos) => element[field] = dbValues[pos])
-
-                if (element.type) {
-                    return callback(null, element);
-                } else {
-                    return callback(null, null);
-                }
-
             }
+
+            var paramsMap = {};
+
+            authParamsKeys.forEach((key, index) => {
+                if (authValues[index]) {
+                    paramsMap[authParams[key].name] = authParams[key].parser(authValues[index]);
+                }
+            })
+
+            callback(null, paramsMap);
         });
     };
+
+    /*******************************************************************************************************************
+     * END AUTH
+     ******************************************************************************************************************/
 
     return me;
 };

--- a/test/carto_metadata.test.js
+++ b/test/carto_metadata.test.js
@@ -334,17 +334,18 @@ test('retrieves empty if there are no async slaves', function(done){
     });
 
     test('can retrieve an API Key', function (done) {
-        MetaData.getApiKey({
-                username: 'vizzuality',
-                apiKeyToken: '1234567890123456789012345678901234567890'
-            }, function (err, dbparams) {
+        const username = 'vizzuality';
+        const apiKeyToken = '1234567890123456789012345678901234567890';
+        const apiName = 'maps';
+
+        MetaData.getApiKey(username,apiKeyToken, apiName, function (err, dbparams) {
             assert.equal(err, null, "Did not expect an err");
             assert.deepEqual(dbparams, {
                 "type": "regular",
                 "user": "vizzuality",
                 "dbRole": "vizzuality_1234",
                 "dbPassword": "1234",
-                "grants_maps": true
+                "grantsMaps": true
             });
             done();
         });

--- a/test/support/prepare_db.sh
+++ b/test/support/prepare_db.sh
@@ -63,11 +63,9 @@ cat <<EOF | redis-cli -p ${REDIS_PORT} -n 5
 HMSET api_keys:vizzuality:1234567890123456789012345678901234567890  \
                              type regular \
                              user vizzuality \
-                             dbRole vizzuality_1234 \
-                             dbPassword 1234 \
+                             db_role vizzuality_1234 \
+                             db_password 1234 \
                              grants_maps true
 EOF
 
 echo "ok, you can run test now"
-
-


### PR DESCRIPTION
Follow existing conventions for this module:
 - Expose .getApiKey() to use arguments list
 - Keep snake_case notation for keys stored in redis
 - Don't keep state at module's top-level

Added:
 - Map keys in redis to expose them using camelCase notation
 - Parse redis values (strings) to javascript native types

Also, it fixes test related to get api-key from redis