### PR TITLE
supporting redis4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,205 @@
+{
+    "name": "cartodb-redis",
+    "version": "0.14.1",
+    "lockfileVersion": 1,
+    "requires": true,
+    "dependencies": {
+        "bindings": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.3.0.tgz",
+            "integrity": "sha512-DpLh5EzMR2kzvX1KIlVC0VkC3iZtHKTgdtZ0a3pglBZdaQFjt5S9g9xd1lE+YvXyfd6mtCeRnrUfOLYiTMlNSw=="
+        },
+        "commander": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-2.0.0.tgz",
+            "integrity": "sha1-0bhvkB+LZL2UG96tr5JFMDk76Sg=",
+            "dev": true
+        },
+        "debug": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+            "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+            "dev": true,
+            "requires": {
+                "ms": "2.0.0"
+            }
+        },
+        "diff": {
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/diff/-/diff-1.0.7.tgz",
+            "integrity": "sha1-JLuwAcSn1VIhaefKvbLCgU7ZHPQ=",
+            "dev": true
+        },
+        "dot": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/dot/-/dot-1.0.3.tgz",
+            "integrity": "sha1-+HUL+2sDx2ZOsObLHrTGZBmvlCc="
+        },
+        "double-ended-queue": {
+            "version": "2.1.0-0",
+            "resolved": "https://registry.npmjs.org/double-ended-queue/-/double-ended-queue-2.1.0-0.tgz",
+            "integrity": "sha1-ED01J/0xUo9AGIEwyEHv3XgmTlw="
+        },
+        "generic-pool": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/generic-pool/-/generic-pool-2.1.1.tgz",
+            "integrity": "sha1-rwTcLDJc/Ll1Aj+lK/zpYXp0Nf0="
+        },
+        "glob": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.3.tgz",
+            "integrity": "sha1-4xPusknHr/qlxHUoaw4RW1mDlGc=",
+            "dev": true,
+            "requires": {
+                "graceful-fs": "2.0.3",
+                "inherits": "2.0.3",
+                "minimatch": "0.2.14"
+            }
+        },
+        "graceful-fs": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz",
+            "integrity": "sha1-fNLNsiiko/Nule+mzBQt59GhNtA=",
+            "dev": true
+        },
+        "growl": {
+            "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/growl/-/growl-1.7.0.tgz",
+            "integrity": "sha1-3i1mE20ALhErpw8/EMMc98NQsto=",
+            "dev": true
+        },
+        "hiredis": {
+            "version": "0.5.0",
+            "resolved": "https://registry.npmjs.org/hiredis/-/hiredis-0.5.0.tgz",
+            "integrity": "sha1-2wOpi+zXAD0TwmAEOs7s+s31m4c=",
+            "requires": {
+                "bindings": "1.3.0",
+                "nan": "2.8.0"
+            }
+        },
+        "inherits": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+            "dev": true
+        },
+        "jade": {
+            "version": "0.26.3",
+            "resolved": "https://registry.npmjs.org/jade/-/jade-0.26.3.tgz",
+            "integrity": "sha1-jxDXl32NefL2/4YqgbBRPMslaGw=",
+            "dev": true,
+            "requires": {
+                "commander": "0.6.1",
+                "mkdirp": "0.3.0"
+            },
+            "dependencies": {
+                "commander": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/commander/-/commander-0.6.1.tgz",
+                    "integrity": "sha1-+mihT2qUXVTbvlDYzbMyDp47GgY=",
+                    "dev": true
+                },
+                "mkdirp": {
+                    "version": "0.3.0",
+                    "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz",
+                    "integrity": "sha1-G79asbqCevI1dRQ0kEJkVfSB/h4=",
+                    "dev": true
+                }
+            }
+        },
+        "lru-cache": {
+            "version": "2.7.3",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
+            "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI=",
+            "dev": true
+        },
+        "minimatch": {
+            "version": "0.2.14",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+            "integrity": "sha1-x054BXT2PG+aCQ6Q775u9TpqdWo=",
+            "dev": true,
+            "requires": {
+                "lru-cache": "2.7.3",
+                "sigmund": "1.0.1"
+            }
+        },
+        "mkdirp": {
+            "version": "0.3.5",
+            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz",
+            "integrity": "sha1-3j5fiWHIjHh+4TaN+EmsRBPsqNc=",
+            "dev": true
+        },
+        "mocha": {
+            "version": "1.15.1",
+            "resolved": "https://registry.npmjs.org/mocha/-/mocha-1.15.1.tgz",
+            "integrity": "sha1-MIwyaOFrCxaQ2IM1NVydGNRmT8Q=",
+            "dev": true,
+            "requires": {
+                "commander": "2.0.0",
+                "debug": "3.1.0",
+                "diff": "1.0.7",
+                "glob": "3.2.3",
+                "growl": "1.7.0",
+                "jade": "0.26.3",
+                "mkdirp": "0.3.5"
+            }
+        },
+        "ms": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+            "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+            "dev": true
+        },
+        "nan": {
+            "version": "2.8.0",
+            "resolved": "https://registry.npmjs.org/nan/-/nan-2.8.0.tgz",
+            "integrity": "sha1-7XFfP+neArV6XmJS2QqWZ14fCFo="
+        },
+        "redis": {
+            "version": "2.8.0",
+            "resolved": "https://registry.npmjs.org/redis/-/redis-2.8.0.tgz",
+            "integrity": "sha512-M1OkonEQwtRmZv4tEWF2VgpG0JWJ8Fv1PhlgT5+B+uNq2cA3Rt1Yt/ryoR+vQNOQcIEgdCdfH0jr3bDpihAw1A==",
+            "requires": {
+                "double-ended-queue": "2.1.0-0",
+                "redis-commands": "1.3.1",
+                "redis-parser": "2.6.0"
+            }
+        },
+        "redis-commands": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/redis-commands/-/redis-commands-1.3.1.tgz",
+            "integrity": "sha1-gdgm9F+pyLIBH0zXoP5ZfSQdRCs="
+        },
+        "redis-mpool": {
+            "version": "github:cartodb/node-redis-mpool#3775bd7fcae78d2255894bfb320a6f125c9ad93c",
+            "requires": {
+                "generic-pool": "2.1.1",
+                "hiredis": "0.5.0",
+                "redis": "2.8.0",
+                "underscore": "1.6.0"
+            }
+        },
+        "redis-parser": {
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-2.6.0.tgz",
+            "integrity": "sha1-Uu0J2srBCPGmMcB+m2mUHnoZUEs="
+        },
+        "sigmund": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+            "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=",
+            "dev": true
+        },
+        "strftime": {
+            "version": "0.9.2",
+            "resolved": "https://registry.npmjs.org/strftime/-/strftime-0.9.2.tgz",
+            "integrity": "sha1-vMooYfKUVtNyqvaheBHIvG859YM=",
+            "dev": true
+        },
+        "underscore": {
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
+            "integrity": "sha1-izixDKze9jM3uLJOT/htRa6lKag="
+        }
+    }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -171,7 +171,9 @@
             "integrity": "sha1-gdgm9F+pyLIBH0zXoP5ZfSQdRCs="
         },
         "redis-mpool": {
-            "version": "github:cartodb/node-redis-mpool#3775bd7fcae78d2255894bfb320a6f125c9ad93c",
+            "version": "0.5.0",
+            "resolved": "https://registry.npmjs.org/redis-mpool/-/redis-mpool-0.5.0.tgz",
+            "integrity": "sha512-dD1KAEXvf7hw+9sejSh0Pe0OFdAA3gRUA9W+BdTbBtxoK/SDQHCcSzhHZg9lHxdAtEeMEmggoAVckNrK1qz3Gg==",
             "requires": {
                 "generic-pool": "2.1.1",
                 "hiredis": "0.5.0",

--- a/package.json
+++ b/package.json
@@ -16,9 +16,9 @@
         "Sandro Santilli <strk@vizzuality.com>"
     ],
     "dependencies": {
-        "underscore": "~1.6.0",
         "dot": "~1.0.2",
-        "redis-mpool": "cartodb/node-redis-mpool#redis4"
+        "redis-mpool": "^0.5.0",
+        "underscore": "~1.6.0"
     },
     "devDependencies": {
         "strftime": "~0.9.2",

--- a/package.json
+++ b/package.json
@@ -11,14 +11,14 @@
     },
     "author": "Vizzuality <contact@vizzuality.com> (http://vizzuality.com)",
     "contributors": [
-      "Simon Tokumine <simon@vizzuality.com>",
-      "Javi Santana <jsantana@vizzuality.com>",
-      "Sandro Santilli <strk@vizzuality.com>"
+        "Simon Tokumine <simon@vizzuality.com>",
+        "Javi Santana <jsantana@vizzuality.com>",
+        "Sandro Santilli <strk@vizzuality.com>"
     ],
     "dependencies": {
         "underscore": "~1.6.0",
         "dot": "~1.0.2",
-        "redis-mpool": "~0.4.1"
+        "redis-mpool": "cartodb/node-redis-mpool#redis4"
     },
     "devDependencies": {
         "strftime": "~0.9.2",
@@ -27,5 +27,7 @@
     "scripts": {
         "test": "./run_tests.sh test/*"
     },
-    "engine": { "node": ">= 0.6 < 0.11" }
+    "engine": {
+        "node": ">= 0.6 < 0.11"
+    }
 }

--- a/package.json
+++ b/package.json
@@ -28,6 +28,6 @@
         "test": "./run_tests.sh test/*"
     },
     "engine": {
-        "node": ">= 0.6 < 0.11"
+        "node": ">= 0.6"
     }
 }


### PR DESCRIPTION
Solving a part of CartoDB/Windshaft-cartodb#819
Main PR CartoDB/Windshaft-cartodb#849

Updating node-redis package adding Redis 4 support

Of course, this change must be work with Redis 3.