### PR TITLE
Adding field "streaming_mode" to user redis

### DIFF
--- a/lib/carto_metadata.js
+++ b/lib/carto_metadata.js
@@ -202,6 +202,9 @@ module.exports = function(redis_opts) {
             id: 'dbuser',
             database_password: 'dbpass',
             map_key: 'apikey',
+            // this field indicates whether SQL API streams the
+            // data or returns all results at once.
+            // see https://app.clubhouse.io/cartoteam/story/106733/turn-sql-api-transactional-and-improve-the-error-handling
             streaming_mode: 'streamingmode'
         };
         this.getMultipleUserDBParams(username, dbParams, callback);

--- a/lib/carto_metadata.js
+++ b/lib/carto_metadata.js
@@ -201,7 +201,8 @@ module.exports = function(redis_opts) {
             database_publicuser: 'dbpublicuser',
             id: 'dbuser',
             database_password: 'dbpass',
-            map_key: 'apikey'
+            map_key: 'apikey',
+            streaming_mode: 'streamingmode'
         };
         this.getMultipleUserDBParams(username, dbParams, callback);
     };

--- a/test/carto_metadata.test.js
+++ b/test/carto_metadata.test.js
@@ -154,7 +154,8 @@ test('retrieves empty if there are no async slaves', function(done){
                 "dbpublicuser": "publicuser",
                 "dbuser": "1",
                 "dbpass": "secret",
-                "apikey": "1234"
+                "apikey": "1234",
+                "streamingmode": "false"
             });
             done();
         });

--- a/test/support/prepare_db.sh
+++ b/test/support/prepare_db.sh
@@ -24,7 +24,8 @@ HMSET rails:users:vizzuality id 1 \
                              database_name ${TEST_DB} \
                              database_host localhost \
                              database_publicuser publicuser \
-                             database_password secret map_key 1234
+                             database_password secret map_key 1234 \
+                             streaming_mode false
 SADD rails:users:vizzuality:map_key 1235
 HMSET limits:timeout:vizzuality render 5000 render_public 4000
 EOF


### PR DESCRIPTION
The current behaviour of the SQL API is to stream results from the user DB. However, several customers want to retrieve all the results at once instead of using streaming and they do not want to change their code to do that.

By those reasons we've proposed adding a flag called `streaming_mode` in redis for the user which indicates if the response will be streamed or not (true by default).

This PR has changes to read this field from the redis.